### PR TITLE
Resolve overlaps

### DIFF
--- a/maup/__init__.py
+++ b/maup/__init__.py
@@ -2,14 +2,15 @@ from .adjacencies import adjacencies
 from .assign import assign
 from .indexed_geometries import IndexedGeometries
 from .intersections import intersections, prorate
-from .repair import close_gaps
+from .repair import close_gaps, resolve_overlaps
 
 __version__ = "0.5"
 __all__ = [
     "assign",
-    "IndexedGeometries",
     "intersections",
     "prorate",
     "adjacencies",
     "close_gaps",
+    "resolve_overlaps",
+    "IndexedGeometries",
 ]

--- a/maup/adjacencies.py
+++ b/maup/adjacencies.py
@@ -27,6 +27,12 @@ def iter_adjacencies(geometries):
 def adjacencies(
     geometries, adjacency_type="rook", *, warn_for_overlaps=True, warn_for_islands=True
 ):
+    """Returns adjacencies between geometries. The return type is a
+    `GeoSeries` with a `MultiIndex`, whose (i, j)th entry is the pairwise
+    intersection between geometry `i` and geometry `j`. We ensure that
+    `i < j` always holds, so that any adjacency is represented just once
+    in the series.
+    """
     if adjacency_type not in ["rook", "queen"]:
         raise ValueError('adjacency_type must be "rook" or "queen"')
 

--- a/maup/intersections.py
+++ b/maup/intersections.py
@@ -47,11 +47,11 @@ def intersections(sources, targets, area_cutoff=None):
 def prorate(relationship, data, weights, aggregate_by="sum"):
     """
     Prorate data from one set of geometries to another, using their
-    `~maup.intersections`.
+    `~maup.intersections` or an assignment.
 
-    :param inters: the :func:`~maup.intersections` of the geometries you are
+    :param relationship: the :func:`~maup.intersections` of the geometries you are
         getting data from (sources) and the geometries you are moving the data
-        to
+        to; or, a series assigning sources to targets
     :type inters: :class:`geopandas.GeoSeries`
     :param data: the data you want to move (must be indexed the same as
         the source geometries)

--- a/maup/repair.py
+++ b/maup/repair.py
@@ -1,3 +1,5 @@
+import pandas
+
 from geopandas import GeoSeries
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import unary_union
@@ -9,12 +11,14 @@ from .indexed_geometries import get_geometries
 from .intersections import intersections
 
 
-def holes_of_union(geometries):
-    """Returns any holes in the union of the given geometries.
+"""
+These functions are based on the functions in Mary Barker's
+check_shapefile_connectivity.py script in @gerrymandr/Preprocessing.
+"""
 
-    This is adapted from `check_for_holes` in Mary Barker's
-    check_shapefile_connectivity.py script in @gerrymandr/Preprocessing.
-    """
+
+def holes_of_union(geometries):
+    """Returns any holes in the union of the given geometries."""
     geometries = get_geometries(geometries)
     if not all(
         isinstance(geometry, (Polygon, MultiPolygon)) for geometry in geometries
@@ -43,6 +47,15 @@ def holes(geometry):
 
 
 def close_gaps(geometries, relative_threshold=0.1):
+    """Closes gaps between geometries by assigning the hole to the polygon
+    that shares the most perimeter with the hole.
+
+    If the area of the gap is greater than `relative_threshold` times the
+    area of the polygon, then the gap is left alone. The default value
+    of `relative_threshold` is 0.1. This is intended to preserve intentional
+    gaps while closing the tiny gaps that can occur as artifacts of
+    geospatial operations. Set `relative_threshold=None` to close all gaps.
+    """
     geometries = get_geometries(geometries)
     gaps = holes_of_union(geometries)
     return absorb_by_shared_perimeter(
@@ -51,17 +64,44 @@ def close_gaps(geometries, relative_threshold=0.1):
 
 
 def resolve_overlaps(geometries, relative_threshold=0.1):
+    """For any pair of overlapping geometries, assigns the overlapping area to the
+    geometry that shares the most perimeter with the overlap. Returns the GeoSeries
+    of geometries, which will have no overlaps.
+
+    If the ratio of the overlap's area to either of the overlapping geometries'
+    areas is greater than `relative_threshold`, then the overlap is ignored.
+    The default `relative_threshold` is `0.1`. This default is chosen to include
+    tiny overlaps that can be safely auto-fixed while preserving major overlaps
+    that might indicate deeper issues and should be handled on a case-by-case
+    basis. Set `relative_threshold=None` to resolve all overlaps.
+    """
     geometries = get_geometries(geometries)
     inters = adjacencies(geometries, warn_for_islands=False, warn_for_overlaps=False)
     overlaps = inters[inters.area > 0]
 
+    if relative_threshold is not None:
+        left_areas, right_areas = split_by_level(geometries.area, overlaps.index)
+        under_threshold = ((overlaps.area / left_areas) < relative_threshold) & (
+            (overlaps.area / right_areas) < relative_threshold
+        )
+        overlaps = overlaps[under_threshold]
+
     if len(overlaps) == 0:
         return geometries
 
-    # Remove overlaps arbitrarily
-    levels_to_drop = list(range(1, overlaps.index.nlevels))
-    to_remove = overlaps.droplevel(levels_to_drop)
-    return geometries.difference(to_remove)
+    to_remove = pandas.concat([overlaps.droplevel(1), overlaps.droplevel(0)])
+    with_overlaps_removed = geometries.difference(to_remove)
+
+    return absorb_by_shared_perimeter(
+        overlaps, with_overlaps_removed, relative_threshold=None
+    )
+
+
+def split_by_level(series, multiindex):
+    return tuple(
+        multiindex.get_level_values(i).to_series(index=multiindex).map(series)
+        for i in range(multiindex.nlevels)
+    )
 
 
 @require_same_crs
@@ -76,11 +116,13 @@ def absorb_by_shared_perimeter(sources, targets, relative_threshold=None):
 
     if relative_threshold is not None:
         under_threshold = (
-            sources.area / GeoSeries(assignment.map(targets)).area
+            sources.area / assignment.map(targets.area)
         ) < relative_threshold
         assignment = assignment[under_threshold]
 
     sources_to_absorb = GeoSeries(
         sources.groupby(assignment).apply(unary_union), crs=sources.crs
     )
-    return targets.union(sources_to_absorb)
+    result = targets.union(sources_to_absorb)
+
+    return result

--- a/tests/test_holes.py
+++ b/tests/test_holes.py
@@ -4,7 +4,14 @@ import geopandas
 import pytest
 from shapely.geometry import Point, Polygon
 
-from maup.repair import close_gaps, holes, holes_of_union, absorb_by_shared_perimeter
+from maup.repair import (
+    close_gaps,
+    holes,
+    holes_of_union,
+    absorb_by_shared_perimeter,
+    resolve_overlaps,
+    adjacencies,
+)
 
 
 def square_at(lower_left_corner, side_length=1):
@@ -151,3 +158,20 @@ class TestAbsorbBySharedPerimeters:
 
         with pytest.raises(IndexError):
             absorb_by_shared_perimeter(sources, targets)
+
+
+def test_overlaps_remove_overlaps():
+    # 00x11
+    # 00x11
+    # 00x11
+    square1 = square_at((0, 0), side_length=3)
+    square2 = square_at((2, 0), side_length=3)
+    geometries = geopandas.GeoSeries([square1, square2])
+    result = resolve_overlaps(geometries, relative_threshold=None)
+
+    inters = adjacencies(result)
+    assert not (inters.area > 0).any()
+
+
+def test_overlaps_returns_same_if_no_overlaps(four_square_grid):
+    assert resolve_overlaps(four_square_grid) is four_square_grid.geometry

--- a/tests/test_holes.py
+++ b/tests/test_holes.py
@@ -160,18 +160,73 @@ class TestAbsorbBySharedPerimeters:
             absorb_by_shared_perimeter(sources, targets)
 
 
-def test_overlaps_remove_overlaps():
-    # 00x11
-    # 00x11
-    # 00x11
-    square1 = square_at((0, 0), side_length=3)
-    square2 = square_at((2, 0), side_length=3)
-    geometries = geopandas.GeoSeries([square1, square2])
-    result = resolve_overlaps(geometries, relative_threshold=None)
+class TestResolveOverlaps:
+    def test_removes_overlaps(self):
+        # 00x11
+        # 00x11
+        # 00x11
+        square1 = square_at((0, 0), side_length=3)
+        square2 = square_at((2, 0), side_length=3)
+        geometries = geopandas.GeoSeries([square1, square2])
+        result = resolve_overlaps(geometries, relative_threshold=None)
 
-    inters = adjacencies(result)
-    assert not (inters.area > 0).any()
+        inters = adjacencies(result)
+        assert not (inters.area > 0).any()
 
+    def test_returns_same_if_no_overlaps(self, four_square_grid):
+        assert resolve_overlaps(four_square_grid) is four_square_grid.geometry
 
-def test_overlaps_returns_same_if_no_overlaps(four_square_grid):
-    assert resolve_overlaps(four_square_grid) is four_square_grid.geometry
+    def test_assigns_overlap_by_max_shared_perimeter(self):
+        """The overlapping area should be assigned to the polygon that shares
+        the most perimeter with the overlap.
+        """
+        # 000
+        # 00x1
+        # 00x1
+        square1 = square_at((0, 0), side_length=3)
+        square2 = square_at((2, 0), side_length=2)
+        geometries = geopandas.GeoSeries([square1, square2])
+        result = resolve_overlaps(geometries, relative_threshold=None)
+
+        # Expected:
+        # 000
+        # 0001
+        # 0001
+        assert result[0].equals(square1)
+        assert result[1].equals(Polygon([(3, 0), (3, 2), (4, 2), (4, 0)]))
+
+    def test_threshold(self):
+        # 000
+        # 00x1
+        # 00x1
+        square1 = square_at((0, 0), side_length=3)
+        square2 = square_at((2, 0), side_length=2)
+        geometries = geopandas.GeoSeries([square1, square2])
+        # This threshold is low enough that nothing should happen:
+        result = resolve_overlaps(geometries, relative_threshold=0.0001)
+
+        # Expected:
+        # 000
+        # 00x1
+        # 00x1
+        print(result)
+        assert result[0].equals(square1)
+        assert result[1].equals(square2)
+
+    def test_threshold_rules_out_one_but_not_both(self):
+        # 000
+        # 00x1
+        # 00x1
+        square1 = square_at((0, 0), side_length=3)
+        square2 = square_at((2, 0), side_length=2)
+        geometries = geopandas.GeoSeries([square1, square2])
+
+        # It's under threshold w.r.t square1 but not square 2
+        result = resolve_overlaps(geometries, relative_threshold=0.4)
+
+        # Expected:
+        # 000
+        # 00x1
+        # 00x1
+        assert result[0].equals(square1)
+        assert result[1].equals(square2)


### PR DESCRIPTION
This adds a `resolve_overlaps` function that fixes overlaps between geometries. This brings us to feature parity with the `check_shapefile_connectivity.py` script in gerrymandr/Preprocessing.