### PR TITLE
Raise TypeError for CRS mismatch

### DIFF
--- a/maup/crs.py
+++ b/maup/crs.py
@@ -5,11 +5,12 @@ def require_same_crs(f):
     @wraps(f)
     def wrapped(*args, **kwargs):
         geoms1, geoms2, *rest = args
-        assert (
-            geoms1.crs == geoms2.crs
-        ), "The source and target geometries must have the same CRS. {} {}".format(
-            geoms1.crs, geoms2.crs
-        )
+        if not geoms1.crs == geoms2.crs:
+            raise TypeError(
+                "the source and target geometries must have the same CRS. {} {}".format(
+                    geoms1.crs, geoms2.crs
+                )
+            )
         return f(*args, **kwargs)
 
     return wrapped

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -10,5 +10,5 @@ def test_require_same_crs(square, four_square_grid):
     def f(sources, targets):
         raise RuntimeError("Something went wrong.")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         f(square, four_square_grid)


### PR DESCRIPTION
The previous behavior was to assert that they match. TypeError seems more appropriate than AssertionError.