### PR TITLE
Set CRS in `adjacencies`

### DIFF
--- a/maup/__init__.py
+++ b/maup/__init__.py
@@ -5,7 +5,7 @@ from .intersections import intersections, prorate
 from .repair import close_gaps, resolve_overlaps
 from .normalize import normalize
 
-__version__ = "0.5"
+__version__ = "0.6"
 __all__ = [
     "assign",
     "intersections",

--- a/maup/adjacencies.py
+++ b/maup/adjacencies.py
@@ -37,7 +37,7 @@ def adjacencies(
         raise ValueError('adjacency_type must be "rook" or "queen"')
 
     index, geoms = zip(*iter_adjacencies(geometries))
-    inters = GeoSeries(geoms, index=index)
+    inters = GeoSeries(geoms, index=index, crs=geometries.crs)
 
     if adjacency_type == "rook":
         inters = inters[inters.length > 0]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "0.5"
+version = "0.6"
 
 with open("./README.md") as f:
     long_description = f.read()

--- a/tests/test_adjacencies.py
+++ b/tests/test_adjacencies.py
@@ -32,3 +32,9 @@ class TestAdjacencies:
 
         for geom in adjs:
             assert isinstance(geom, BaseGeometry)
+
+    def test_sets_crs(self, four_square_grid):
+        assert four_square_grid.crs
+
+        adjs = adjacencies(four_square_grid)
+        assert adjs.crs == four_square_grid.crs


### PR DESCRIPTION
`maup.adjacencies` returns a GeoSeries of all the pairwise intersections of the input geometries. This should have the same CRS as the original geometries. This PR sets that CRS and includes a test to verify this behavior.