### PR TITLE
Fix IndexedGeometries for Shapely==1.7.1, see #29

### DIFF
--- a/maup/indexed_geometries.py
+++ b/maup/indexed_geometries.py
@@ -13,12 +13,12 @@ class IndexedGeometries:
         self.geometries = get_geometries(geometries)
         geoms = list(self.geometries)
         for i, geometry in enumerate(geoms):
-            geometry.id = i
+            geometry.index = i
         self.spatial_index = STRtree(geoms)
         self.index = self.geometries.index
 
     def query(self, geometry):
-        relevant_indices = [geom.id for geom in self.spatial_index.query(geometry)]
+        relevant_indices = [geom.index for geom in self.spatial_index.query(geometry)]
         relevant_geometries = self.geometries.loc[relevant_indices]
         return relevant_geometries
 

--- a/maup/indexed_geometries.py
+++ b/maup/indexed_geometries.py
@@ -1,23 +1,28 @@
 import pandas
 from shapely.prepared import prep
 from shapely.strtree import STRtree
+from shapely.geometry import mapping
 from .progress_bar import progress
 
 
 def get_geometries(geometries):
     return getattr(geometries, "geometry", geometries)
 
+def hash_geom(geom):
+    return hash(tuple(mapping(geom)['coordinates']))
+
 
 class IndexedGeometries:
     def __init__(self, geometries):
         self.geometries = get_geometries(geometries)
+        self._index = {}
         for i, geometry in self.geometries.items():
-            geometry.index = i
+            self._index[hash_geom(geometry)] = i
         self.spatial_index = STRtree(self.geometries)
         self.index = self.geometries.index
 
     def query(self, geometry):
-        relevant_indices = [geom.index for geom in self.spatial_index.query(geometry)]
+        relevant_indices = [self._index[hash_geom(geom)] for geom in self.spatial_index.query(geometry)]
         relevant_geometries = self.geometries.loc[relevant_indices]
         return relevant_geometries
 
@@ -47,3 +52,4 @@ class IndexedGeometries:
         for i, target in progress(target_geometries.items(), len(target_geometries)):
             for j, intersection in self.intersections(target).items():
                 yield i, j, intersection
+

--- a/maup/indexed_geometries.py
+++ b/maup/indexed_geometries.py
@@ -12,8 +12,8 @@ class IndexedGeometries:
     def __init__(self, geometries):
         self.geometries = get_geometries(geometries)
         geoms = list(self.geometries)
-        for i, geometry in enumerate(geoms):
-            geometry.index = i
+        for i, idx in enumerate(self.geometries.index):
+            geoms[i].index = idx
         self.spatial_index = STRtree(geoms)
         self.index = self.geometries.index
 

--- a/maup/indexed_geometries.py
+++ b/maup/indexed_geometries.py
@@ -1,28 +1,24 @@
 import pandas
 from shapely.prepared import prep
 from shapely.strtree import STRtree
-from shapely.geometry import mapping
 from .progress_bar import progress
 
 
 def get_geometries(geometries):
     return getattr(geometries, "geometry", geometries)
 
-def hash_geom(geom):
-    return hash(tuple(mapping(geom)['coordinates']))
-
 
 class IndexedGeometries:
     def __init__(self, geometries):
         self.geometries = get_geometries(geometries)
-        self._index = {}
-        for i, geometry in self.geometries.items():
-            self._index[hash_geom(geometry)] = i
-        self.spatial_index = STRtree(self.geometries)
+        geoms = list(self.geometries)
+        for i, geometry in enumerate(geoms):
+            geometry.id = i
+        self.spatial_index = STRtree(geoms)
         self.index = self.geometries.index
 
     def query(self, geometry):
-        relevant_indices = [self._index[hash_geom(geom)] for geom in self.spatial_index.query(geometry)]
+        relevant_indices = [geom.id for geom in self.spatial_index.query(geometry)]
         relevant_geometries = self.geometries.loc[relevant_indices]
         return relevant_geometries
 


### PR DESCRIPTION
When using Shapely 1.7.1 `IndexedGeometries.query` fails because the assigned `geom.index` values don't persist. 

[Shapely documentation suggests](https://github.com/Toblerity/Shapely/blob/9667fe86b6668deb319e6eb0479bc84e5f6e73ee/shapely/strtree.py#L163) building your own index:

        To get the original indices of the returned objects, create an
        auxiliary dictionary. But use the geometry *ids* as keys since
        the shapely geometry objects themselves are not hashable.

        >>> index_by_id = dict((id(pt), i) for i, pt in enumerate(points))
        >>> [(index_by_id[id(pt)], pt.wkt) for pt in tree.query(Point(2,2).buffer(1.0))]
        [(1, 'POINT (1 1)'), (2, 'POINT (2 2)'), (3, 'POINT (3 3)')]

The problem with this particular approach is that using `id` is unreliable--multiple objects may have the same `id` throughout the lifecycle of a program.

Instead I'm using a kind of ugly way to generate a hash for a given geometry.