### PR TITLE
Fix TypeError when nothing is assigned by covering

### DIFF
--- a/maup/assign.py
+++ b/maup/assign.py
@@ -11,8 +11,11 @@ def assign(sources, targets):
     """
     assignment = assign_by_covering(sources, targets)
     unassigned = sources[assignment.isna()]
-    assignments_by_area = assign_by_area(unassigned, targets)
-    assignment.update(assignments_by_area)
+
+    if len(unassigned):  # skip if done
+        assignments_by_area = assign_by_area(unassigned, targets)
+        assignment.update(assignments_by_area)
+
     assignment.name = None
     return assignment.astype(targets.index.dtype, errors="ignore")
 

--- a/maup/assign.py
+++ b/maup/assign.py
@@ -1,3 +1,5 @@
+import pandas
+
 from .indexed_geometries import IndexedGeometries
 from .intersections import intersections
 from .crs import require_same_crs
@@ -9,14 +11,20 @@ def assign(sources, targets):
     target that covers it, or, if no target covers the entire source, the
     target that covers the most of its area.
     """
-    assignment = assign_by_covering(sources, targets)
+    assignment = pandas.Series(
+        assign_by_covering(sources, targets),
+        dtype="float"
+    )
+    assignment.name = None
     unassigned = sources[assignment.isna()]
 
     if len(unassigned):  # skip if done
-        assignments_by_area = assign_by_area(unassigned, targets)
+        assignments_by_area = pandas.Series(
+            assign_by_area(unassigned, targets),
+            dtype="float"
+        )
         assignment.update(assignments_by_area)
 
-    assignment.name = None
     return assignment.astype(targets.index.dtype, errors="ignore")
 
 

--- a/maup/indexed_geometries.py
+++ b/maup/indexed_geometries.py
@@ -45,8 +45,11 @@ class IndexedGeometries:
                 target_geometries.items(), len(target_geometries)
             )
         ]
-        assignment = pandas.concat(groups).reindex(self.index)
-        return assignment
+        if groups:
+            return pandas.concat(groups).reindex(self.index)
+        else:
+            return geopandas.GeoSeries()
+
 
     def enumerate_intersections(self, targets):
         target_geometries = get_geometries(targets)


### PR DESCRIPTION
When nothing is assigned by area, the type of `assignment` is a `geometry` object, which results in a `TypeError`. Coercing the types to a float resolves this issue.