### PR TITLE
Create "force_polygon" argument for topological repair

### DIFF
--- a/maup/repair.py
+++ b/maup/repair.py
@@ -42,7 +42,10 @@ def make_valid(geometries, force_polygons=False):
     data from the output."""
     geometries = geometries.make_valid()
     if force_polygons:
+        # Map function causes CRS information to be dropped.
+        srs = geometries.crs.srs
         geometries = geometries.map(trim_valid)
+        geometries = geometries.set_crs(srs)
     return geometries
 
 
@@ -353,7 +356,6 @@ def absorb_by_shared_perimeter(sources, targets, relative_threshold=None, force_
         raise IndexError("targets must be nonempty")
 
     inters = make_valid(intersections(sources, targets, area_cutoff=None), force_polygons)
-
     assignment = assign_to_max(inters.length)
 
     if relative_threshold is not None:


### PR DESCRIPTION
I've experienced frequent issues with the topological repair functions when resolving errors from moving between certain projections. The functions tend to crash because of Line Segment fragments that are created after shapely's "make_valid" method. This fix adds an optional "force_polygon" argument that if enabled iterates through any resulting "GeometryCollection" objects and filters out any non-polygonal results.