### PR TITLE
Fix issue in from_records not tracking crs correctly in intersections function

### DIFF
--- a/maup/intersections.py
+++ b/maup/intersections.py
@@ -37,13 +37,11 @@ def intersections(sources, targets, output_type="geoseries", area_cutoff=None):
         )
     ]
 
-    df = GeoDataFrame.from_records(records, columns=["source", "target", "geometry"])
+    df = GeoDataFrame(records, columns=["source", "target", "geometry"], crs=sources.crs)
     df = df.sort_values(by=["source", "target"]).reset_index(drop=True)
-    df.crs = sources.crs
 
     geometries = df.set_index(["source", "target"]).geometry
     geometries.sort_index(inplace=True)
-    geometries.crs = sources.crs
 
     if area_cutoff is not None:
         df = df[df.area > area_cutoff].reset_index(drop=True)

--- a/tests/test_intersections.py
+++ b/tests/test_intersections.py
@@ -73,7 +73,7 @@ def manually_compute_intersections(sources, targets):
                 records.append((i, j, intersection))
 
     expected = (
-        geopandas.GeoDataFrame.from_records(
+        geopandas.GeoDataFrame(
             records, columns=["source", "target", "geometry"]
         )
         .set_index(["source", "target"])


### PR DESCRIPTION
This is a quick fix for #95. The main issue is that the from_records function is inherited from the pandas library, and it does not track so when it creates a GeoDataFrame from a list of records, it does not assign the column labeled "geometry" as a geometry column, and, with the new change to pandas 2, it looks like this ends up throwing the following error:

ValueError: Assigning CRS to a GeoDataFrame without a geometry column is not supported. Use GeoDataFrame.set_geometry to set the active geometry column.`

If we use the constructor for the GeoDataFrame object intead, then geopandas correctly handles the geometry column, and we can assign the crs to the GeoDataFrame object directly.